### PR TITLE
Handle img error in Avatar

### DIFF
--- a/docs/components/avatar.md
+++ b/docs/components/avatar.md
@@ -1,5 +1,6 @@
 <script setup>
 import AvatarExample from './avatar/examples/AvatarExample.vue'
+import AvatarImageErrorPlaceholderFallbackExample from './avatar/examples/AvatarImageErrorPlaceholderFallbackExample.vue'
 import AvatarBorderedExample from './avatar/examples/AvatarBorderedExample.vue'
 import AvatarDotIndicatorExample from './avatar/examples/AvatarDotIndicatorExample.vue'
 import AvatarSizeExample from './avatar/examples/AvatarSizeExample.vue'
@@ -27,6 +28,22 @@ import { Avatar } from 'flowbite-vue'
         <Avatar status="online" img="https://flowbite.com/docs/images/people/profile-picture-5.jpg" />
         <Avatar status="online" rounded img="https://flowbite.com/docs/images/people/profile-picture-5.jpg" />
     </div>
+</template>
+```
+
+## Image Error Handling
+This example shows that the `Avatar` will fall back to the placeholder icon in case there is any error locaing the specified `img`. 
+
+<AvatarImageErrorPlaceholderFallbackExample />
+
+```vue
+<script setup>
+import { Avatar } from 'flowbite-vue'
+</script>
+<template>
+  <div class="vp-raw flex">
+    <Avatar status="online" img="https://flowbite.com/docs/images/people/profile-picture-not-found.jpg" />
+  </div>
 </template>
 ```
 

--- a/docs/components/avatar/examples/AvatarImageErrorPlaceholderFallbackExample.vue
+++ b/docs/components/avatar/examples/AvatarImageErrorPlaceholderFallbackExample.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="vp-raw flex">
+    <Avatar status="online" img="https://flowbite.com/docs/images/people/profile-picture-not-found.jpg" />
+  </div>
+</template>
+<script setup>
+import { Avatar } from '../../../../src/index'
+</script>

--- a/src/components/Avatar/Avatar.vue
+++ b/src/components/Avatar/Avatar.vue
@@ -1,20 +1,25 @@
 <template>
   <div class="relative">
-    <div v-if="!img" :class="avatarPlaceholderWrapperClasses">
+    <img v-if="img && !imageError" :class="avatarClasses" :src="img" :alt="alt" @error="setImageError">
+    <div v-else :class="avatarPlaceholderWrapperClasses">
       <svg v-if="!initials" :class="avatarPlaceholderClasses" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
         <path fill-rule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clip-rule="evenodd"></path>
       </svg>
       <div v-else :class="avatarPlaceholderInitialsClasses">{{ initials }}</div>
     </div>
-    <img v-else :class="avatarClasses" :src="img" :alt="alt">
     <span v-if="status" :class="avatarDotClasses" :data-pos="statusPosition"></span>
   </div>
 </template>
 <script lang="ts" setup>
-import { toRefs } from 'vue'
+import { ref, toRefs } from 'vue'
 import type { PropType } from 'vue'
 import type { AvatarSize, AvatarStatus, AvatarStatusPosition } from './types'
 import { useAvatarClasses } from '@/components/Avatar/composables/useAvatarClasses'
+
+const imageError = ref(false)
+function setImageError() {
+  imageError.value = true
+}
 
 const props = defineProps({
   alt: {


### PR DESCRIPTION
Fall back to the default placeholder image in the case of an error loading the specified `img` on an `Avatar`.